### PR TITLE
Change mrio-amazonka liftResourceT to avoid redundant do statement

### DIFF
--- a/amazonka/src/MRIO/Amazonka.hs
+++ b/amazonka/src/MRIO/Amazonka.hs
@@ -43,8 +43,7 @@ class HasResourceMap env where
   resourceMap :: env -> ResourceMap
 
 instance HasResourceMap env => MonadResource (RIO env) where
-  liftResourceT (ResourceT run) = do
-    (liftIO . run) =<< asks resourceMap
+  liftResourceT (ResourceT run) = (liftIO . run) =<< asks resourceMap
 
 type HasAWS env = (MonadResource (RIO env), HasAWSEnv env)
 


### PR DESCRIPTION
Fix a `hlint` suggestion to avoid a redundant `do` statement.

### Acceptance

* [ ] Green CI